### PR TITLE
Remove rte config from tca, fix text cleanup from linebreaks

### DIFF
--- a/Classes/Service/DestinationDataImportService.php
+++ b/Classes/Service/DestinationDataImportService.php
@@ -423,13 +423,13 @@ class DestinationDataImportService
             }
 
             if ($text['rel'] == "details" && $text['type'] == "text/plain") {
-                $this->tmpCurrentEvent->setDetails(str_replace('\n\n', '\n', $text['value']));
+                $this->tmpCurrentEvent->setDetails(str_replace("\n\n", "\n", $text['value']));
             }
             if ($text['rel'] == "teaser" && $text['type'] == "text/plain") {
-                $this->tmpCurrentEvent->setTeaser(str_replace('\n\n', '\n', $text['value']));
+                $this->tmpCurrentEvent->setTeaser(str_replace("\n\n", "\n", $text['value']));
             }
             if ($text['rel'] == "PRICE_INFO" && $text['type'] == "text/plain") {
-                $this->tmpCurrentEvent->setPriceInfo(str_replace('\n\n', '\n', $text['value']));
+                $this->tmpCurrentEvent->setPriceInfo(str_replace("\n\n", "\n", $text['value']));
             }
         }
     }

--- a/Configuration/TCA/tx_events_domain_model_event.php
+++ b/Configuration/TCA/tx_events_domain_model_event.php
@@ -232,7 +232,6 @@ return [
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
-                'richtextConfiguration' => 'Default',
                 'fieldControl' => [
                     'fullScreenRichtext' => [
                         'disabled' => false,

--- a/Documentation/Changelog/3.2.2.rst
+++ b/Documentation/Changelog/3.2.2.rst
@@ -1,0 +1,28 @@
+3.2.2
+=====
+
+Breaking
+--------
+
+Nothing
+
+Features
+--------
+
+Nothing
+
+Fixes
+-----
+
+* Remove missing rte config from events TCA
+* Fix linebreak replacement in import
+
+Tasks
+-----
+
+Nothing
+
+Deprecation
+-----------
+
+Nothing

--- a/Tests/Functional/Import/DestinationDataTest/Assertions/ImportsExampleAsExpected.csv
+++ b/Tests/Functional/Import/DestinationDataTest/Assertions/ImportsExampleAsExpected.csv
@@ -11,10 +11,8 @@ Um Voranmeldung unter 03672-486470 oder schillerhaus@rudolstadt.de wird gebeten.
 Es gilt die 2G-PLUS-Regel.",,"http://www.schillerhaus.rudolstadt.de/",,,,,"1","1",,"1","1",,"1",,1,"allerlei-weihnachtliches-heute-mit-johannes-geisser"
 ,"2","2","0","0","0","0","0","-1","0","0","0","0","0","Tüftlerzeit",,"e_100354481","e-100354481","0",,"Die Tüftlerzeit wird dieses Mal ein weihnachtliches Angebot bereithalten. Alle kleinen Tüftler dürfen gespannt sein.
 Voranmeldung über: kinderbibliothek@rudolstadt.de oder 03672-486420
-
 Bitte beachten Sie die derzeit geltenden Zugangsregeln.",,"http://www.stadtbibliothek-rudolstadt.de/",,,,,"1","1",,"4","2",,"1",,2,"tueftlerzeit"
 ,"3","2","0","0","0","0","0","-1","0","0","0","0","0","Adventliche Orgelmusik (Orgel: KMD Frank Bettenhausen)",,"e_100350503","e-100350503","0",,"Immer mittwochs in der Adventszeit spielt Frank Bettenhausen solo und zusammen mit anderen Musikern auf der Steinmeyerorgel aus dem Jahr 1906.  Bekannte Adventslieder, barocke und romantische Kompositionen stehen neben besinnlichen Texten von Pfarrer Johannes-Martin Weiss.
-
 Es gilt die 2G-PLUS-Regel.",,,,,,,"1","2",,"8","3",,"1",,3,"adventliche-orgelmusik-orgel-kmd-frank-bettenhausen"
 "tx_events_domain_model_date",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,"uid","pid","cruser_id","hidden","starttime","endtime","sys_language_uid","l10n_parent","t3ver_oid","t3ver_wsid","t3ver_state","event","start","end","canceled","postponed_date","canceled_link","slug",,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
The wrong RTE config reference breaks detail text in be view.
str_replace id not work with single quotes to remove double linebreaks.