### PR TITLE
Improve TYPO3 cache handling

### DIFF
--- a/Tests/Functional/Frontend/DatesTest.php
+++ b/Tests/Functional/Frontend/DatesTest.php
@@ -25,12 +25,11 @@ namespace Wrm\Events\Tests\Functional\Frontend;
 
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use Wrm\Events\Frontend\Dates;
-use Wrm\Events\Tests\Functional\AbstractFunctionalTestCase;
 
 /**
  * @covers \Wrm\Events\Frontend\Dates
  */
-class DatesTest extends AbstractFunctionalTestCase
+class DatesTest extends AbstractTestCase
 {
     protected $testExtensionsToLoad = [
         'typo3conf/ext/events',

--- a/Tests/Functional/Frontend/FilterTest.php
+++ b/Tests/Functional/Frontend/FilterTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Wrm\Events\Tests\Functional\Frontend;
 
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use Wrm\Events\Tests\Functional\AbstractFunctionalTestCase;
 
 /**
  * @covers \Wrm\Events\Controller\DateController
  * @covers \Wrm\Events\Domain\Repository\DateRepository
  */
-class FilterTest extends AbstractFunctionalTestCase
+class FilterTest extends AbstractTestCase
 {
     protected $testExtensionsToLoad = [
         'typo3conf/ext/events',

--- a/Tests/Functional/Frontend/Fixtures/Extensions/example/Classes/UserFunc.php
+++ b/Tests/Functional/Frontend/Fixtures/Extensions/example/Classes/UserFunc.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace Wrm\EventsExample;
+
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+class UserFunc
+{
+    /**
+     * @var ContentObjectRenderer
+     */
+    public $cObj;
+
+    public function accessTsfeTimeout(): string
+    {
+        return 'get_cache_timeout: ' . $this->getTsfe()->get_cache_timeout();
+    }
+
+    public function sleep(string $content, array $configuration): string
+    {
+        $sleep = (int) $this->cObj->stdWrapValue('sleep', $configuration['userFunc.'], 0);
+        sleep($sleep);
+        return 'Sleep for ' . $sleep . ' seconds';
+    }
+
+    public function getTsfe(): TypoScriptFrontendController
+    {
+        return $GLOBALS['TSFE'];
+    }
+}

--- a/Tests/Functional/Frontend/Fixtures/Extensions/example/composer.json
+++ b/Tests/Functional/Frontend/Fixtures/Extensions/example/composer.json
@@ -5,6 +5,11 @@
     "require": {
         "wrm/events": "*"
     },
+    "autoload": {
+        "psr-4": {
+            "Wrm\\EventsExample\\": "Classes/"
+        }
+    },
     "extra": {
         "typo3/cms": {
             "extension-key": "example"

--- a/Tests/Functional/Frontend/Fixtures/TypoScript/Rendering.typoscript
+++ b/Tests/Functional/Frontend/Fixtures/TypoScript/Rendering.typoscript
@@ -6,7 +6,24 @@ config {
 
 page = PAGE
 page {
-    10 < styles.content.get
+    10 = USER
+    10 {
+        // Simulates foreign access prior our rendering.
+        // TYPO3 has an internal cache in order to not recalculate timeout.
+        userFunc = Wrm\EventsExample\UserFunc->accessTsfeTimeout
+    }
+
+    20 < styles.content.get
+
+    30 = USER
+    30 {
+        // Simulates further long running rendering.
+        // In order to test that our ttl is calculated as expected.
+        userFunc = Wrm\EventsExample\UserFunc->sleep
+        userFunc {
+            sleep = 0
+        }
+    }
 }
 
 plugin.tx_events {


### PR DESCRIPTION
There might be access to TSFE get_cache_timeout() prior rendering events.
TYPO3 has a cache for timeout and won't re calculate again. We therefore need to clear the cache if timeout would change.

That will lead to inconsistent cache information throughout a single request. But the final cache timeout of the page will be correct. Other parts might be longer, which probably is fine until they relate to the events.

Relates: #10500