### PR TITLE
Allow to show only upcoming events

### DIFF
--- a/Classes/Domain/Model/Dto/DateDemand.php
+++ b/Classes/Domain/Model/Dto/DateDemand.php
@@ -77,9 +77,18 @@ class DateDemand
     protected $endObject = null;
 
     /**
+     * Use midnight as "start".
+     *
      * @var bool
      */
     protected $useMidnight = true;
+
+    /**
+     * Only show dates that have not started yet.
+     *
+     * @var bool
+     */
+    protected $upcoming = false;
 
     /**
      * @var string
@@ -361,13 +370,25 @@ class DateDemand
     public function setUseMidnight(bool $useMidnight): void
     {
         $this->useMidnight = $useMidnight;
+        $this->upcoming = false;
+    }
+
+    public function setUpcoming(bool $upcoming): void
+    {
+        $this->startObject = null;
+        $this->endObject = null;
+        $this->useMidnight = false;
+
+        $this->upcoming = $upcoming;
     }
 
     public function shouldShowFromNow(): bool
     {
         return $this->getStartObject() === null
             && $this->getEndObject() === null
-            && $this->useMidnight === false;
+            && $this->useMidnight === false
+            && $this->upcoming === false
+        ;
     }
 
     public function shouldShowFromMidnight(): bool
@@ -375,6 +396,11 @@ class DateDemand
         return $this->getStartObject() === null
             && $this->getEndObject() === null
             && $this->useMidnight === true;
+    }
+
+    public function shouldShowUpcoming(): bool
+    {
+        return $this->upcoming === true;
     }
 
     public function getConsiderDate(): bool

--- a/Classes/Domain/Model/Dto/DateDemandFactory.php
+++ b/Classes/Domain/Model/Dto/DateDemandFactory.php
@@ -99,6 +99,9 @@ class DateDemandFactory
         if (isset($settings['useMidnight'])) {
             $demand->setUseMidnight((bool)$settings['useMidnight']);
         }
+        if (isset($settings['upcoming'])) {
+            $demand->setUpcoming((bool)$settings['upcoming']);
+        }
         if (!empty($settings['limit'])) {
             $demand->setLimit($settings['limit']);
         }

--- a/Documentation/Changelog/3.4.0.rst
+++ b/Documentation/Changelog/3.4.0.rst
@@ -17,6 +17,13 @@ Features
 
   That allows visitors to always see the next dates.
 
+* Add ``upcoming`` setting for dates.
+
+  The option can be set to ``0`` (default) or ``1``.
+  ``0`` behaves the same way as in the past.
+  ``1`` turns off the option ``useMidnight``, ``start`` and ``end``.
+  Only dates with a start date in the future will be shown.
+
 Fixes
 -----
 

--- a/Documentation/Settings.rst
+++ b/Documentation/Settings.rst
@@ -3,6 +3,28 @@
 Settings
 ========
 
+Frontend
+--------
+
+The frontend can be configured via TYPO3 Extbase defaults.
+
+``stdWrap`` is applied to all options.
+
+.. option:: settings.useMidnight
+
+   Can be set to ``1`` (default) or ``0``.
+
+   | ``0`` will show dates starting from now.
+   | ``1`` will use midnight of configured start date.
+
+.. option:: settings.upcoming
+
+   Can be set to ``0`` (default) or ``1``.
+
+   | ``0`` does not alter the behaviour.
+   | ``1`` turns off the option ``useMidnight``, ``start`` and ``end``.
+   | Only dates with a start date in the future will be shown.
+
 Import
 ------
 

--- a/Tests/Functional/Frontend/DatesTest.php
+++ b/Tests/Functional/Frontend/DatesTest.php
@@ -172,4 +172,34 @@ class DatesTest extends AbstractTestCase
         self::assertStringContainsString('Event 8', $html);
         self::assertStringContainsString('Event 9', $html);
     }
+
+    /**
+     * @test
+     */
+    public function returnsUpcomingDates(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/DatesTestFixtures/ReturnsUpcomingDates.php');
+
+        $request = new InternalRequest();
+        $request = $request->withPageId(1);
+        $request = $request->withInstructions([
+            $this->getTypoScriptInstruction()
+                ->withTypoScript([
+                    'plugin.' => [
+                        'tx_events.' => [
+                            'settings.' => [
+                                'upcoming' => '1',
+                            ],
+                        ],
+                    ],
+                ])
+        ]);
+        $response = $this->executeFrontendRequest($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $html = (string) $response->getBody();
+
+        self::assertStringNotContainsString('Event 1', $html);
+        self::assertStringContainsString('Event 2', $html);
+    }
 }

--- a/Tests/Functional/Frontend/DatesTestFixtures/ReturnsUpcomingDates.php
+++ b/Tests/Functional/Frontend/DatesTestFixtures/ReturnsUpcomingDates.php
@@ -1,0 +1,43 @@
+<?php
+
+use DateTimeImmutable;
+
+return [
+    'tt_content' => [
+        [
+            'uid' => 1,
+            'pid' => 1,
+            'CType' => 'list',
+            'list_type' => 'events_datelist',
+            'header' => 'Upcoming Dates',
+        ],
+    ],
+    'tx_events_domain_model_event' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'title' => 'Event 1',
+        ],
+        [
+            'uid' => 2,
+            'pid' => 2,
+            'title' => 'Event 2',
+        ],
+    ],
+    'tx_events_domain_model_date' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'event' => 1,
+            'start' => (new DateTimeImmutable())->modify('-5 minutes')->format('U'),
+            'end' => (new DateTimeImmutable())->modify('+5 minutes')->format('U'),
+        ],
+        [
+            'uid' => 2,
+            'pid' => 2,
+            'event' => 2,
+            'start' => (new DateTimeImmutable())->modify('+5 minutes')->format('U'),
+            'end' => (new DateTimeImmutable())->modify('+15 minutes')->format('U'),
+        ],
+    ],
+];


### PR DESCRIPTION
A new TypoScript option upcoming is added.
The option can be set to 0 (default) or 1.
0 behaves the same way as in the past.
1 turns off the option useMidnight, start and end. Only dates with a start date in the future will be shown.

Relates: #10507