### PR TITLE
Fix wrong detection of Page Cache timeout (TTL)

### DIFF
--- a/Classes/Caching/PageCacheTimeout.php
+++ b/Classes/Caching/PageCacheTimeout.php
@@ -120,7 +120,7 @@ class PageCacheTimeout implements SingletonInterface
             $newTimeout <= $now
             || (
                 $this->timeout instanceof DateTimeImmutable
-                && $this->timeout >= $newTimeout
+                && $this->timeout <= $newTimeout
             )
         ) {
             return;


### PR DESCRIPTION
Use the earliest instead of latest timeout.
Extend tests to cover the bug.

Relates: #10506