### PR TITLE
Reduce broken time frame due to missing slugs

### DIFF
--- a/Classes/Service/DestinationDataImportService.php
+++ b/Classes/Service/DestinationDataImportService.php
@@ -260,11 +260,10 @@ class DestinationDataImportService
             $this->logger->info('Persist database');
             $this->eventRepository->update($this->tmpCurrentEvent);
             $this->persistenceManager->persistAll();
+            $this->logger->info('Update slugs');
+            $this->slugger->update('tx_events_domain_model_event');
+            $this->slugger->update('tx_events_domain_model_date');
         }
-
-        $this->logger->info('Update slugs');
-        $this->slugger->update('tx_events_domain_model_event');
-        $this->slugger->update('tx_events_domain_model_date');
 
         $this->logger->info('Finished import');
         return 0;

--- a/Documentation/Changelog/3.4.0.rst
+++ b/Documentation/Changelog/3.4.0.rst
@@ -43,6 +43,13 @@ Fixes
   It didn't check if a file that could be deleted because one event got deleted,
   was still in use by another event.
 
+* Generate slugs after each single event was imported.
+  This should prevent a situation where a large amount of events is imported without
+  having slugs.
+  Routing might break depending on configuration.
+  The time range where this can happen is now reduced as slugs for each event and
+  date is generated right after saving each of them.
+
 Tasks
 -----
 


### PR DESCRIPTION
Dates are vanished and re created during import.
Slugs for dates were generate after whole import was finished. This is now changed to generate slugs for dates after saving each single event.