### PR TITLE
Do not download already existing files during import

### DIFF
--- a/Classes/Service/DestinationDataImportService/FilesAssignment.php
+++ b/Classes/Service/DestinationDataImportService/FilesAssignment.php
@@ -93,11 +93,7 @@ class FilesAssignment
 
             if ($importFolder->hasFile($orgFileNameSanitized)) {
                 $this->logger->info('File already exists.', [$orgFileNameSanitized]);
-            } else {
-                $this->logger->info('File does not exist.', [$orgFileNameSanitized]);
-            }
-
-            if ($filename = $this->loadFile($fileUrl)) {
+            } elseif ($filename = $this->loadFile($fileUrl)) {
                 $this->logger->info('Adding file to FAL.', [$filename]);
                 $importFolder->addFile($filename, basename($fileUrl), DuplicationBehavior::REPLACE);
             } else {

--- a/Documentation/Changelog/3.4.0.rst
+++ b/Documentation/Changelog/3.4.0.rst
@@ -34,6 +34,7 @@ Features
 * Handle changes to images for events.
   The import of destination data one only added new images but kept existing images untouched.
   This was now improved. The import now will update, remove and re-sort images as well.
+  Existing image files won't be downloaded again, only information and position are updated.
 
 Fixes
 -----

--- a/Documentation/Features/ImportDestinationOne.rst
+++ b/Documentation/Features/ImportDestinationOne.rst
@@ -21,6 +21,7 @@ The import will:
 * Flush all dates for updated events and re-create all dates.
 
 * Add and update all images for updated and added events.
+  Existing image files won't be downloaded again, only information and position are updated.
 
 The import will not:
 


### PR DESCRIPTION
The usual use cases right now would involve a new file with a new URL. That way we don't need to download existing files again. That reduced network traffic, execution time and resource usage.