### PR TITLE
Add event to modify categories during destination data one import

### DIFF
--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -2,15 +2,22 @@
 
 namespace Wrm\Events\Domain\Model;
 
-use TYPO3\CMS\Extbase\Domain\Model\Category as ExtbaseCategory;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
 
 /**
  * Extend original model to include furher properties.
  *
  * Used for Plugins and Import.
  */
-class Category extends ExtbaseCategory
+class Category extends AbstractEntity
 {
+    /**
+     * @var string
+     */
+    protected $title = '';
+
     /**
      * @var int
      */
@@ -21,13 +28,46 @@ class Category extends ExtbaseCategory
      */
     protected $hidden = false;
 
+    /**
+     * @var Category|null
+     *
+     * @Extbase\ORM\Lazy
+     */
+    protected $parent;
+
+    /**
+     * @param Category|null $parent
+     */
+    public function __construct(
+        $parent,
+        int $pid,
+        string $title,
+        bool $hidden
+    ) {
+        $this->parent = $parent;
+        $this->pid = $pid;
+        $this->title = $title;
+        $this->hidden = $hidden;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
     public function getSorting(): int
     {
         return $this->sorting;
     }
 
-    public function hide(): void
+    /**
+     * @return Category|null
+     */
+    public function getParent()
     {
-        $this->hidden = true;
+        if ($this->parent instanceof LazyLoadingProxy) {
+            $this->parent->_loadRealInstance();
+        }
+        return $this->parent;
     }
 }

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -24,9 +24,9 @@ namespace Wrm\Events\Domain\Repository;
  */
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Extbase\Domain\Model\Category;
 use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use Wrm\Events\Domain\Model\Category;
 
 class CategoryRepository extends Repository
 {

--- a/Classes/Service/DestinationDataImportService.php
+++ b/Classes/Service/DestinationDataImportService.php
@@ -23,6 +23,7 @@ use Wrm\Events\Service\DestinationDataImportService\CategoriesAssignment;
 use Wrm\Events\Service\DestinationDataImportService\CategoriesAssignment\Import as CategoryImport;
 use Wrm\Events\Service\DestinationDataImportService\DataFetcher;
 use Wrm\Events\Service\DestinationDataImportService\DatesFactory;
+use Wrm\Events\Service\DestinationDataImportService\Events\CategoriesAssignEvent;
 use Wrm\Events\Service\DestinationDataImportService\Events\EventImportEvent;
 use Wrm\Events\Service\DestinationDataImportService\FilesAssignment;
 use Wrm\Events\Service\DestinationDataImportService\LocationAssignment;
@@ -310,7 +311,13 @@ class DestinationDataImportService
             $categories
         ));
 
-        $this->tmpCurrentEvent->setCategories($categories);
+        $event = new CategoriesAssignEvent(
+            $this->tmpCurrentEvent,
+            $categories
+        );
+        $this->eventDispatcher->dispatch($event);
+
+        $this->tmpCurrentEvent->setCategories($event->getCategories());
     }
 
     private function setFeatures(array $features): void

--- a/Classes/Service/DestinationDataImportService/CategoriesAssignment.php
+++ b/Classes/Service/DestinationDataImportService/CategoriesAssignment.php
@@ -46,13 +46,12 @@ class CategoriesAssignment
             );
 
             if (!$category instanceof Category) {
-                $category = new Category();
-                $category->setParent($import->getParentCategory());
-                $category->setPid($import->getPid());
-                $category->setTitle($categoryTitle);
-                if ($import->getHideByDefault()) {
-                    $category->hide();
-                }
+                $category = new Category(
+                    $import->getParentCategory(),
+                    $import->getPid(),
+                    $categoryTitle,
+                    $import->getHideByDefault() ? true : false
+                );
                 $this->repository->add($category);
             }
 

--- a/Classes/Service/DestinationDataImportService/Events/CategoriesAssignEvent.php
+++ b/Classes/Service/DestinationDataImportService/Events/CategoriesAssignEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace Wrm\Events\Service\DestinationDataImportService\Events;
+
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use Wrm\Events\Domain\Model\Category;
+use Wrm\Events\Domain\Model\Event;
+
+final class CategoriesAssignEvent
+{
+    /**
+     * @var Event
+     */
+    private $event;
+
+    /**
+     * @var ObjectStorage<Category>
+     */
+    private $categories;
+
+    /**
+     * @param ObjectStorage<Category> $categories
+     */
+    public function __construct(
+        Event $event,
+        ObjectStorage $categories
+    ) {
+        $this->event = $event;
+        $this->setCategories($categories);
+    }
+
+    public function getEvent(): Event
+    {
+        return clone $this->event;
+    }
+
+    /**
+     * @return ObjectStorage<Category>
+     */
+    public function getCategories(): ObjectStorage
+    {
+        return clone $this->categories;
+    }
+
+    /**
+     * @param ObjectStorage<Category> $categories
+     */
+    public function setCategories(ObjectStorage $categories): void
+    {
+        $this->categories = $categories;
+    }
+}

--- a/Documentation/Changelog/3.5.0.rst
+++ b/Documentation/Changelog/3.5.0.rst
@@ -4,7 +4,9 @@
 Breaking
 --------
 
-Nothing
+* We migrated away from Extbase Category model.
+  This is technically breaking, but we don't consider it breaking as this should be an internal detail.
+  Still this might break if you have type checks.
 
 Features
 --------
@@ -15,6 +17,8 @@ Features
   See :ref:`psr14` for an overview of PSR-14 Events.
 
   Added Events:
+
+  * Allow to modify TYPO3 ``sys_categories`` before adding them to an event during import.
 
   * Allow to modify an event object before importing.
 
@@ -37,6 +41,11 @@ Tasks
 
 * Renaming different Destination cases to destination.one throughout documentation and text.
   Code is left untouched in order to not break things.
+
+* Migrate away from Extbase Category to custom Category.
+  The extension already provided its own Category model.
+  TYPO3 deprecated and will remove the default Models.
+  We consider this none breaking as this is considered to be internal API.
 
 Deprecation
 -----------

--- a/Documentation/Features/PSR14Events.rst
+++ b/Documentation/Features/PSR14Events.rst
@@ -4,6 +4,14 @@
 PSR-14 Events
 =============
 
+.. index:: single: PSR-14 Events; destination.one Import: Categories Assign
+
+destination.one Import: ``CategoriesAssignEvent``
+-------------------------------------------------
+
+Executed during destination.one Import.
+Allows to alter the categories to assign to an event.
+
 .. index:: single: PSR-14 Events; destination.one Import: Event Import
 
 destination.one Import: ``EventImportEvent``

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Assertions/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.php
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Assertions/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.php
@@ -1,0 +1,90 @@
+<?php
+
+return [
+    'tx_events_domain_model_import' => [
+        [
+            'uid' => '1',
+            'pid' => '2',
+            'title' => 'Example import configuration',
+            'storage_pid' => 2,
+            'files_folder' => '1:/staedte/beispielstadt/events/',
+            'region' => '1',
+            'rest_experience' => 'beispielstadt',
+            'categories_pid' => 2,
+            'category_parent' => 2,
+        ],
+    ],
+    'sys_category' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'parent' => 0,
+            'title' => 'Events Root',
+        ],
+        [
+            'uid' => 2,
+            'pid' => 2,
+            'parent' => 1,
+            'title' => 'Events Categories',
+        ],
+        [
+            'uid' => 3,
+            'pid' => 2,
+            'parent' => 1,
+            'title' => 'Custom Parent',
+        ],
+        [
+            'uid' => 4,
+            'pid' => 2,
+            'parent' => 3,
+            'title' => 'Custom Category',
+        ],
+        [
+            'uid' => 5,
+            'pid' => 2,
+            'parent' => 2,
+            'title' => 'Konzerte, Festivals, Show & Tanz',
+        ],
+        [
+            'uid' => 6,
+            'pid' => 2,
+            'parent' => 2,
+            'title' => 'Weihnachten',
+        ],
+    ],
+    'tx_events_domain_model_event' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'title' => 'Event for categories event',
+            'global_id' => 'e_100350503',
+            'categories' => 3,
+        ],
+    ],
+    'sys_category_record_mm' => [
+        [
+            'uid_local' => 4,
+            'uid_foreign' => 1,
+            'tablenames' => 'tx_events_domain_model_event',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 3,
+        ],
+        [
+            'uid_local' => 5,
+            'uid_foreign' => 1,
+            'tablenames' => 'tx_events_domain_model_event',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 1,
+        ],
+        [
+            'uid_local' => 6,
+            'uid_foreign' => 1,
+            'tablenames' => 'tx_events_domain_model_event',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 2,
+        ],
+    ],
+];

--- a/Tests/Functional/Psr14Events/DestinationDataImport/CategoriesAssignEventTest.php
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/CategoriesAssignEventTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace Wrm\Events\Tests\Functional\Psr14Events\DestinationDataImport;
+
+use GuzzleHttp\Psr7\Response;
+use Wrm\Events\Tests\Functional\Import\DestinationDataTest\AbstractTest;
+
+final class CategoriesAssignEventTest extends AbstractTest
+{
+    protected function setUp(): void
+    {
+        $this->testExtensionsToLoad[] = 'typo3conf/ext/events/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/';
+
+        parent::setUp();
+
+        $this->setUpConfiguration([
+            'restUrl = https://example.com/some-path/',
+            'license = example-license',
+            'restType = Event',
+            'restLimit = 3',
+            'restMode = next_months,12',
+            'restTemplate = ET2014A.json',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function registeredEventHandlerCanKeepCustomCategoriesAssigned(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/Database/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.php');
+        $this->setUpResponses([new Response(200, [], file_get_contents(__DIR__ . '/Fixtures/Responses/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.json') ?: '')]);
+
+        $this->executeCommand();
+
+        $this->assertPHPDataSet(__DIR__ . '/Assertions/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.php');
+    }
+}

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Database/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.php
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Database/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.php
@@ -1,0 +1,62 @@
+<?php
+
+return [
+    'tx_events_domain_model_import' => [
+        [
+            'uid' => '1',
+            'pid' => '2',
+            'title' => 'Example import configuration',
+            'storage_pid' => 2,
+            'files_folder' => '1:/staedte/beispielstadt/events/',
+            'region' => '1',
+            'rest_experience' => 'beispielstadt',
+            'categories_pid' => 2,
+            'category_parent' => 2,
+        ],
+    ],
+    'sys_category' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'parent' => 0,
+            'title' => 'Events Root',
+        ],
+        [
+            'uid' => 2,
+            'pid' => 2,
+            'parent' => 1,
+            'title' => 'Events Categories',
+        ],
+        [
+            'uid' => 3,
+            'pid' => 2,
+            'parent' => 1,
+            'title' => 'Custom Parent',
+        ],
+        [
+            'uid' => 4,
+            'pid' => 2,
+            'parent' => 3,
+            'title' => 'Custom Category',
+        ],
+    ],
+    'tx_events_domain_model_event' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'title' => 'Event for categories event',
+            'global_id' => 'e_100350503',
+            'categories' => 1,
+        ],
+    ],
+    'sys_category_record_mm' => [
+        [
+            'uid_local' => 4,
+            'uid_foreign' => 1,
+            'tablenames' => 'tx_events_domain_model_event',
+            'fieldname' => 'categories',
+            'sorting' => 0,
+            'sorting_foreign' => 1,
+        ],
+    ],
+];

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/Classes/EventListener/CategoriesAssignListener.php
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/Classes/EventListener/CategoriesAssignListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\CustomCategories\EventListener;
+
+use Wrm\Events\Domain\Model\Category;
+use Wrm\Events\Service\DestinationDataImportService\Events\CategoriesAssignEvent;
+
+final class CategoriesAssignListener
+{
+    public function __invoke(CategoriesAssignEvent $psr14Event): void
+    {
+        $categories = $psr14Event->getCategories();
+
+        foreach ($psr14Event->getEvent()->getCategories() as $category) {
+            $parent = $category->getParent();
+            if (
+                (!$parent instanceof Category)
+                || $parent->getUid() !== 3
+            ) {
+                continue;
+            }
+            $categories->attach($category);
+        }
+
+        $psr14Event->setCategories($categories);
+    }
+}

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/Configuration/Services.php
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/Configuration/Services.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use WerkraumMedia\CustomCategories\EventListener\CategoriesAssignListener;
+use Wrm\Events\Service\DestinationDataImportService\Events\CategoriesAssignEvent;
+
+return static function (ContainerConfigurator $containerConfigurator) {
+    $services = $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+    ;
+
+    $services->load('WerkraumMedia\\CustomCategories\\', '../Classes/');
+    $services->set(CategoriesAssignListener::class)
+        ->tag(
+            'event.listener',
+            [
+                'event' => CategoriesAssignEvent::class,
+            ]
+        )
+    ;
+};

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/composer.json
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "werkraummedia/custom_categories",
+    "description": "Integrates custom project specific categories",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "werkraummedia/events": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "WerkraumMedia\\CustomCategories\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "custom_categories"
+        }
+    }
+}

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/ext_emconf.php
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/ext_emconf.php
@@ -1,0 +1,20 @@
+<?php
+
+$EM_CONF['custom_categories'] = [
+    'title' => 'Custom Categories',
+    'description' => 'Integrates custom event specifics categories',
+    'category' => 'plugin',
+    'author' => 'Daniel Siepmann',
+    'author_email' => 'coding@daniel-siepmann.de',
+    'state' => 'alpha',
+    'createDirs' => '',
+    'clearCacheOnLoad' => 0,
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'event' => '',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Responses/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.json
+++ b/Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Responses/RegisteredEventHandlerCanKeepCustomCategoriesAssigned.json
@@ -1,0 +1,110 @@
+{
+    "status": "OK",
+    "count": 1,
+    "overallcount": 1,
+    "channels": [],
+    "facetGroups": [],
+    "items": [
+        {
+            "global_id": "e_100350503",
+            "id": "100350503",
+            "title": "Event for categories event",
+            "type": "Event",
+            "categories": [
+                "Konzerte, Festivals, Show & Tanz",
+                "Weihnachten"
+            ],
+            "features": [
+            ],
+            "texts": [
+                {
+                    "rel": "details",
+                    "type": "text/html",
+                    "value": "Immer mittwochs in der Adventszeit spielt Frank Bettenhausen solo und zusammen mit anderen Musikern auf der Steinmeyerorgel aus dem Jahr 1906.&nbsp;&nbsp;Bekannte Adventslieder, barocke und romantische Kompositionen stehen neben besinnlichen Texten von Pfarrer Johannes-Martin Weiss.<br><br><strong>Es gilt die 2G-PLUS-Regel.</strong><br>"
+                },
+                {
+                    "rel": "details",
+                    "type": "text/plain",
+                    "value": "Immer mittwochs in der Adventszeit spielt Frank Bettenhausen solo und zusammen mit anderen Musikern auf der Steinmeyerorgel aus dem Jahr 1906.  Bekannte Adventslieder, barocke und romantische Kompositionen stehen neben besinnlichen Texten von Pfarrer Johannes-Martin Weiss.\n\nEs gilt die 2G-PLUS-Regel."
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/plain"
+                }
+            ],
+            "city": "Rudolstadt",
+            "zip": "07407",
+            "street": "Caspar-Schulte-Straße",
+            "phone": "03672 - 48 96 13",
+            "author": "support@hubermedia.de",
+            "media_objects": [
+            ],
+            "keywords": [],
+            "timeIntervals": [
+                {
+                    "weekdays": [],
+                    "start": "2099-12-01T19:00:00+01:00",
+                    "end": "2099-12-01T20:00:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "interval": 1
+                },
+                {
+                    "weekdays": [
+                        "Saturday",
+                        "Sunday"
+                    ],
+                    "start": "2099-11-02T11:00:00+01:00",
+                    "end": "2099-11-02T13:00:00+01:00",
+                    "repeatUntil": "2099-11-25T13:00:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "freq": "Weekly",
+                    "interval": 1
+                },
+                {
+                    "weekdays": [],
+                    "start": "2099-12-22T19:00:00+01:00",
+                    "end": "2099-12-22T20:00:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "interval": 1
+                }
+            ],
+            "name": "Lutherkirche",
+            "addresses": [
+                {
+                    "name": "Städtetourismus in Thüringen e.V.",
+                    "city": "Weimar",
+                    "zip": "99423",
+                    "street": "UNESCO-Platz 1",
+                    "phone": "+49 (3643) 745 314",
+                    "web": "http://www.thueringer-staedte.de",
+                    "email": "verein@thueringer-staedte.de",
+                    "rel": "author"
+                },
+                {
+                    "name": "Städtetourismus in Thüringen\" e.V.",
+                    "web": "http://www.thueringer-staedte.de",
+                    "email": "verein@thueringer-staedte.de",
+                    "rel": "organisation"
+                },
+                {
+                    "name": "Lutherkirche",
+                    "city": "Rudolstadt",
+                    "zip": "07407",
+                    "street": "Caspar-Schulte-Straße",
+                    "phone": "03672 - 48 96 13",
+                    "rel": "organizer"
+                }
+            ],
+            "created": "2099-11-08T22:15:00+00:00",
+            "changed": "2099-12-14T08:38:00+00:00",
+            "source": {
+                "url": "http://destination.one/",
+                "value": "destination.one"
+            }
+        }
+    ]
+}

--- a/Tests/Unit/Domain/Model/CategoryTest.php
+++ b/Tests/Unit/Domain/Model/CategoryTest.php
@@ -17,7 +17,12 @@ class CategoryTest extends TestCase
      */
     public function canBeCreated(): void
     {
-        $subject = new Category();
+        $subject = new Category(
+            null,
+            10,
+            'Title',
+            false
+        );
 
         self::assertInstanceOf(
             Category::class,
@@ -30,7 +35,12 @@ class CategoryTest extends TestCase
      */
     public function returnsSorting(): void
     {
-        $subject = new Category();
+        $subject = new Category(
+            null,
+            10,
+            'Title',
+            false
+        );
         $subject->_setProperty('sorting', 10);
 
         self::assertSame(10, $subject->getSorting());
@@ -39,13 +49,30 @@ class CategoryTest extends TestCase
     /**
      * @test
      */
-    public function canHide(): void
+    public function canBeVisible(): void
     {
-        $subject = new Category();
+        $subject = new Category(
+            null,
+            10,
+            'Title',
+            false
+        );
 
         self::assertFalse($subject->_getProperty('hidden'));
+    }
 
-        $subject->hide();
+    /**
+     * @test
+     */
+    public function canHide(): void
+    {
+        $subject = new Category(
+            null,
+            10,
+            'Title',
+            true
+        );
+
         self::assertTrue($subject->_getProperty('hidden'));
     }
 }

--- a/Tests/Unit/Domain/Model/EventTest.php
+++ b/Tests/Unit/Domain/Model/EventTest.php
@@ -32,10 +32,10 @@ class EventTest extends TestCase
      */
     public function returnsSortedFeatures(): void
     {
-        $feature1 = new Category();
-        $feature1->_setProperty('sorting', 10);
-        $feature2 = new Category();
-        $feature2->_setProperty('sorting', 5);
+        $feature1 = $this->createStub(Category::class);
+        $feature1->method('getSorting')->willReturn(10);
+        $feature2 = $this->createStub(Category::class);
+        $feature2->method('getSorting')->willReturn(5);
 
         $storage = new ObjectStorage();
         $storage->attach($feature1);

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "autoload-dev": {
         "psr-4": {
             "Wrm\\Events\\Tests\\": "Tests",
+            "WerkraumMedia\\CustomCategories\\": "Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_categories/Classes/",
             "WerkraumMedia\\CustomEvent\\": "Tests/Functional/Psr14Events/DestinationDataImport/Fixtures/Extensions/custom_event/Classes/"
         }
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: Classes/Controller/DateController.php
 
 		-
+			message: "#^Instanceof between Wrm\\\\Events\\\\Domain\\\\Model\\\\Category\\|null and TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\LazyLoadingProxy will always evaluate to false\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Category.php
+
+		-
 			message: "#^Parameter \\#1 \\$categories of method Wrm\\\\Events\\\\Domain\\\\Model\\\\Event\\:\\:setCategories\\(\\) expects TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\<Wrm\\\\Events\\\\Domain\\\\Model\\\\Category\\>, TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\<mixed\\> given\\.$#"
 			count: 1
 			path: Classes/Service/DestinationDataImportService.php


### PR DESCRIPTION
A new PSR-14 event is added that allows to modify the categories to be assigned to an event.
The event itself (including already existing categories) as well as the list of categories to be used after import are available. It is possible to change the categories to be assigned, e.g. keep some of the existing categories.

That way it is possible for installations to add custom categories to events.

Relates: #10623