### PR TITLE
Update PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "jangregor/phpstan-prophecy": "1.0.0",
         "phpspec/prophecy-phpunit": "^1.0 || ^2.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "1.5.7",
+        "phpstan/phpstan": "1.10.28",
         "phpstan/phpstan-phpunit": "1.1.1",
         "saschaegerer/phpstan-typo3": "1.1.2",
         "squizlabs/php_codesniffer": "^3.5",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: Classes/Service/DestinationDataImportService.php
 
 		-
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, 'strval' given\\.$#"
+			count: 1
+			path: Classes/Domain/DestinationData/ImportFactory.php
+
+		-
 			message: "#^Parameter \\#2 \\$array of function array_map expects array, mixed given\\.$#"
 			count: 1
 			path: Classes/Domain/DestinationData/ImportFactory.php


### PR DESCRIPTION
PHPStan triggers a deprecation on PHP 8.2, but that got fixed with an update.