### PR TITLE
Add source while importing from Destination Data One

### DIFF
--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -140,6 +140,16 @@ class Event extends AbstractEntity
      */
     protected $dataProcessing;
 
+    /**
+     * @var string
+     */
+    protected $sourceName = '';
+
+    /**
+     * @var string
+     */
+    protected $sourceUrl = '';
+
     public function __construct()
     {
         $this->initStorageObjects();
@@ -468,5 +478,15 @@ class Event extends AbstractEntity
     public function getLocalizedUid(): int
     {
         return $this->_localizedUid;
+    }
+
+    public function setSourceName(string $name): void
+    {
+        $this->sourceName = $name;
+    }
+
+    public function setSourceUrl(string $url): void
+    {
+        $this->sourceUrl = $url;
     }
 }

--- a/Classes/Service/DestinationDataImportService.php
+++ b/Classes/Service/DestinationDataImportService.php
@@ -277,6 +277,10 @@ class DestinationDataImportService
                 $this->setAssets($event['media_objects']);
             }
 
+            if ($event['source'] ?? false) {
+                $this->setSource($event['source']);
+            }
+
             $this->eventDispatcher->dispatch(new EventImportEvent(
                 $existingEvent,
                 $this->tmpCurrentEvent
@@ -486,6 +490,17 @@ class DestinationDataImportService
             $assets
         );
         $this->tmpCurrentEvent->setImages($images);
+    }
+
+    private function setSource(array $source): void
+    {
+        if (isset($source['value'])) {
+            $this->tmpCurrentEvent->setSourceName($source['value']);
+        }
+
+        if (isset($source['url'])) {
+            $this->tmpCurrentEvent->setSourceUrl($source['url']);
+        }
     }
 
     /**

--- a/Configuration/TCA/tx_events_domain_model_event.php
+++ b/Configuration/TCA/tx_events_domain_model_event.php
@@ -28,7 +28,7 @@ return [
     ],
     'types' => [
         '1' => [
-            'showitem' => '--palette--;' . $l10nPathFE . ':palette.general;general,
+            'showitem' => '
                     sys_language_uid,
                     l10n_parent,
                     l10n_diffsource,
@@ -40,6 +40,7 @@ return [
                     slug,
                     ticket,
                     global_id,
+                    --palette--;;source,
                 --div--;' . $l10nPath . ':tx_events_domain_model_event.tabs.text,
                     details,
                     price_info,
@@ -67,7 +68,12 @@ return [
                     endtime',
         ],
     ],
-
+    'palettes' => [
+        'source' => [
+            'label' => $l10nPath . ':tx_events_domain_model_event.palette.source',
+            'showitem' => 'source_name, source_url',
+        ],
+    ],
     'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
@@ -185,6 +191,24 @@ return [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
+            ],
+        ],
+        'source_name' => [
+            'exclude' => true,
+            'label' => $l10nPath . ':tx_events_domain_model_event.source_name',
+            'config' => [
+                'type' => 'input',
+                'readOnly' => true,
+            ],
+        ],
+        'source_url' => [
+            'exclude' => true,
+            'label' => $l10nPath . ':tx_events_domain_model_event.source_url',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputLink',
+                'softref' => 'typolink',
+                'readOnly' => true,
             ],
         ],
         'slug' => [

--- a/Documentation/Changelog/3.5.0.rst
+++ b/Documentation/Changelog/3.5.0.rst
@@ -18,6 +18,11 @@ Features
 
   * Allow to modify an event object before importing.
 
+* Add source to events.
+  Destination Data One provides the original source, either them self or an external.
+  This is now saved in order to make it easier for editors and companies to contact
+  the original source and ask to fix broken data.
+
 Fixes
 -----
 

--- a/Resources/Private/Language/de.locallang_csh_event.xlf
+++ b/Resources/Private/Language/de.locallang_csh_event.xlf
@@ -35,6 +35,10 @@
                 <source>Social Media</source>
                 <target>Social Media</target>
             </trans-unit>
+            <trans-unit id="tx_events_domain_model_event.palette.source">
+                <source>Source</source>
+                <target>Quelle</target>
+            </trans-unit>
             <trans-unit id="tx_events_domain_model_event">
                 <source>Event</source>
                 <target>Veranstaltung</target>
@@ -50,6 +54,14 @@
             <trans-unit id="tx_events_domain_model_event.global_id">
                 <source>Global UID</source>
                 <target>Globale UID</target>
+            </trans-unit>
+            <trans-unit id="tx_events_domain_model_event.source_name">
+                <source>Source Name</source>
+                <target>Name der Quelle</target>
+            </trans-unit>
+            <trans-unit id="tx_events_domain_model_event.source_url">
+                <source>Source URL</source>
+                <target>URL der Quelle</target>
             </trans-unit>
             <trans-unit id="tx_events_domain_model_event.slug">
                 <source>Slug</source>

--- a/Resources/Private/Language/locallang_csh_event.xlf
+++ b/Resources/Private/Language/locallang_csh_event.xlf
@@ -30,6 +30,9 @@
             <trans-unit id="tx_events_domain_model_event.tabs.social">
                 <source>Social Media</source>
             </trans-unit>
+            <trans-unit id="tx_events_domain_model_event.palette.source">
+                <source>Source</source>
+            </trans-unit>
             <trans-unit id="tx_events_domain_model_event.title">
                 <source>Title</source>
             </trans-unit>
@@ -38,6 +41,12 @@
             </trans-unit>
             <trans-unit id="tx_events_domain_model_event.global_id">
                 <source>Global UID</source>
+            </trans-unit>
+            <trans-unit id="tx_events_domain_model_event.source_name">
+                <source>Source Name</source>
+            </trans-unit>
+            <trans-unit id="tx_events_domain_model_event.source_url">
+                <source>Source URL</source>
             </trans-unit>
             <trans-unit id="tx_events_domain_model_event.slug">
                 <source>Slug</source>

--- a/Tests/Functional/Import/DestinationDataTest/Assertions/ImportsSource.php
+++ b/Tests/Functional/Import/DestinationDataTest/Assertions/ImportsSource.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'tx_events_domain_model_event' => [
+        [
+            'uid' => 1,
+            'global_id' => 'e_100347853',
+            'source_name' => 'destination.one',
+            'source_url' => 'http://destination.one/',
+        ],
+        [
+            'uid' => 2,
+            'global_id' => 'e_100347854',
+            'source_name' => 'Foreign Example 1',
+            'source_url' => 'https://example.com',
+        ],
+        [
+            'uid' => 3,
+            'global_id' => 'e_100347855',
+            'source_name' => 'Foreign Example 2',
+            'source_url' => 'https://example.com/something-else',
+        ],
+    ],
+];

--- a/Tests/Functional/Import/DestinationDataTest/Fixtures/ResponseWithSources.json
+++ b/Tests/Functional/Import/DestinationDataTest/Fixtures/ResponseWithSources.json
@@ -1,0 +1,219 @@
+{
+    "status": "OK",
+    "count": 3,
+    "overallcount": 50,
+    "channels": [],
+    "facetGroups": [],
+    "items": [
+        {
+            "global_id": "e_100347853",
+            "id": "100347853",
+            "title": "Allerlei Weihnachtliches (Heute mit Johannes Geißer)",
+            "type": "Event",
+            "categories": [
+            ],
+            "texts": [
+                {
+                    "rel": "details",
+                    "type": "text/html",
+                    "value": "Die Lichter sind entzündet, die Plätzchen duften, man rückt endlich wieder näher zusammen und lauscht den Geschichten. Vier Schauspieler*innen unseres Theaters überraschen mit ihren weihnachtlichen Texten, die sie für uns ausgewählt haben. Dazu plaudern sie über persönliche Anekdoten und erinnern sich an ihre schönsten und verrücktesten Weihnachtsfeste. Und da der Genuss in der Vorweihnachtszeit nicht fehlen darf, wird an jedem Adventssonntag eine andere weihnachtliche Spezialität serviert.<br>Eintritt: 10 € (inkl. Gedeck mit weihnachtlicher Schillerlocke)<br>Um Voranmeldung unter 03672-486470 oder&nbsp;<a data-cke-saved-href=\"mailto:schillerhaus@rudolstadt.de\" href=\"mailto:schillerhaus@rudolstadt.de\">schillerhaus@rudolstadt.de</a>&nbsp;wird gebeten. <br><strong>Es gilt die 2G-PLUS-Regel.</strong>&nbsp;<br>"
+                },
+                {
+                    "rel": "details",
+                    "type": "text/plain",
+                    "value": "Die Lichter sind entzündet, die Plätzchen duften, man rückt endlich wieder näher zusammen und lauscht den Geschichten. Vier Schauspieler*innen unseres Theaters überraschen mit ihren weihnachtlichen Texten, die sie für uns ausgewählt haben. Dazu plaudern sie über persönliche Anekdoten und erinnern sich an ihre schönsten und verrücktesten Weihnachtsfeste. Und da der Genuss in der Vorweihnachtszeit nicht fehlen darf, wird an jedem Adventssonntag eine andere weihnachtliche Spezialität serviert.\nEintritt: 10 € (inkl. Gedeck mit weihnachtlicher Schillerlocke)\nUm Voranmeldung unter 03672-486470 oder schillerhaus@rudolstadt.de wird gebeten.\nEs gilt die 2G-PLUS-Regel."
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/plain"
+                }
+            ],
+            "country": "Deutschland",
+            "areas": [
+                "Rudolstadt und Umgebung"
+            ],
+            "city": "Rudolstadt",
+            "zip": "07407",
+            "street": "Schillerstraße 25",
+            "phone": "+ 49 3672 / 486470",
+            "fax": "+ 49 3672 / 486475",
+            "web": "http://www.schillerhaus.rudolstadt.de/",
+            "email": "schillerhaus@rudolstadt.de",
+            "author": "support@hubermedia.de",
+            "media_objects": [
+            ],
+            "keywords": [],
+            "timeIntervals": [
+                {
+                    "weekdays": [],
+                    "start": "2099-12-19T15:00:00+01:00",
+                    "end": "2099-12-19T16:30:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "interval": 1
+                }
+            ],
+            "name": "Schillerhaus Rudolstadt",
+            "features": [
+            ],
+            "addresses": [
+            ],
+            "created": "2099-10-31T12:29:00+00:00",
+            "changed": "2099-12-14T08:29:00+00:00",
+            "source": {
+                "url": "http://destination.one/",
+                "value": "destination.one"
+            },
+            "company": "",
+            "district": "",
+            "postoffice": "",
+            "phone2": "",
+            "seasons": [],
+            "subitems": [],
+            "hyperObjects": []
+        },
+        {
+            "global_id": "e_100347854",
+            "id": "100347854",
+            "title": "Allerlei Weihnachtliches (Heute mit Johannes Geißer)",
+            "type": "Event",
+            "categories": [
+            ],
+            "texts": [
+                {
+                    "rel": "details",
+                    "type": "text/html",
+                    "value": "Die Lichter sind entzündet, die Plätzchen duften, man rückt endlich wieder näher zusammen und lauscht den Geschichten. Vier Schauspieler*innen unseres Theaters überraschen mit ihren weihnachtlichen Texten, die sie für uns ausgewählt haben. Dazu plaudern sie über persönliche Anekdoten und erinnern sich an ihre schönsten und verrücktesten Weihnachtsfeste. Und da der Genuss in der Vorweihnachtszeit nicht fehlen darf, wird an jedem Adventssonntag eine andere weihnachtliche Spezialität serviert.<br>Eintritt: 10 € (inkl. Gedeck mit weihnachtlicher Schillerlocke)<br>Um Voranmeldung unter 03672-486470 oder&nbsp;<a data-cke-saved-href=\"mailto:schillerhaus@rudolstadt.de\" href=\"mailto:schillerhaus@rudolstadt.de\">schillerhaus@rudolstadt.de</a>&nbsp;wird gebeten. <br><strong>Es gilt die 2G-PLUS-Regel.</strong>&nbsp;<br>"
+                },
+                {
+                    "rel": "details",
+                    "type": "text/plain",
+                    "value": "Die Lichter sind entzündet, die Plätzchen duften, man rückt endlich wieder näher zusammen und lauscht den Geschichten. Vier Schauspieler*innen unseres Theaters überraschen mit ihren weihnachtlichen Texten, die sie für uns ausgewählt haben. Dazu plaudern sie über persönliche Anekdoten und erinnern sich an ihre schönsten und verrücktesten Weihnachtsfeste. Und da der Genuss in der Vorweihnachtszeit nicht fehlen darf, wird an jedem Adventssonntag eine andere weihnachtliche Spezialität serviert.\nEintritt: 10 € (inkl. Gedeck mit weihnachtlicher Schillerlocke)\nUm Voranmeldung unter 03672-486470 oder schillerhaus@rudolstadt.de wird gebeten.\nEs gilt die 2G-PLUS-Regel."
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/plain"
+                }
+            ],
+            "country": "Deutschland",
+            "areas": [
+                "Rudolstadt und Umgebung"
+            ],
+            "city": "Rudolstadt",
+            "zip": "07407",
+            "street": "Schillerstraße 25",
+            "phone": "+ 49 3672 / 486470",
+            "fax": "+ 49 3672 / 486475",
+            "web": "http://www.schillerhaus.rudolstadt.de/",
+            "email": "schillerhaus@rudolstadt.de",
+            "author": "support@hubermedia.de",
+            "media_objects": [
+            ],
+            "keywords": [],
+            "timeIntervals": [
+                {
+                    "weekdays": [],
+                    "start": "2099-12-19T15:00:00+01:00",
+                    "end": "2099-12-19T16:30:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "interval": 1
+                }
+            ],
+            "name": "Schillerhaus Rudolstadt",
+            "features": [
+            ],
+            "addresses": [
+            ],
+            "created": "2099-10-31T12:29:00+00:00",
+            "changed": "2099-12-14T08:29:00+00:00",
+            "source": {
+                "url": "https://example.com",
+                "value": "Foreign Example 1"
+            },
+            "company": "",
+            "district": "",
+            "postoffice": "",
+            "phone2": "",
+            "seasons": [],
+            "subitems": [],
+            "hyperObjects": []
+        },
+        {
+            "global_id": "e_100347855",
+            "id": "100347855",
+            "title": "Allerlei Weihnachtliches (Heute mit Johannes Geißer)",
+            "type": "Event",
+            "categories": [
+            ],
+            "texts": [
+                {
+                    "rel": "details",
+                    "type": "text/html",
+                    "value": "Die Lichter sind entzündet, die Plätzchen duften, man rückt endlich wieder näher zusammen und lauscht den Geschichten. Vier Schauspieler*innen unseres Theaters überraschen mit ihren weihnachtlichen Texten, die sie für uns ausgewählt haben. Dazu plaudern sie über persönliche Anekdoten und erinnern sich an ihre schönsten und verrücktesten Weihnachtsfeste. Und da der Genuss in der Vorweihnachtszeit nicht fehlen darf, wird an jedem Adventssonntag eine andere weihnachtliche Spezialität serviert.<br>Eintritt: 10 € (inkl. Gedeck mit weihnachtlicher Schillerlocke)<br>Um Voranmeldung unter 03672-486470 oder&nbsp;<a data-cke-saved-href=\"mailto:schillerhaus@rudolstadt.de\" href=\"mailto:schillerhaus@rudolstadt.de\">schillerhaus@rudolstadt.de</a>&nbsp;wird gebeten. <br><strong>Es gilt die 2G-PLUS-Regel.</strong>&nbsp;<br>"
+                },
+                {
+                    "rel": "details",
+                    "type": "text/plain",
+                    "value": "Die Lichter sind entzündet, die Plätzchen duften, man rückt endlich wieder näher zusammen und lauscht den Geschichten. Vier Schauspieler*innen unseres Theaters überraschen mit ihren weihnachtlichen Texten, die sie für uns ausgewählt haben. Dazu plaudern sie über persönliche Anekdoten und erinnern sich an ihre schönsten und verrücktesten Weihnachtsfeste. Und da der Genuss in der Vorweihnachtszeit nicht fehlen darf, wird an jedem Adventssonntag eine andere weihnachtliche Spezialität serviert.\nEintritt: 10 € (inkl. Gedeck mit weihnachtlicher Schillerlocke)\nUm Voranmeldung unter 03672-486470 oder schillerhaus@rudolstadt.de wird gebeten.\nEs gilt die 2G-PLUS-Regel."
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "teaser",
+                    "type": "text/plain"
+                }
+            ],
+            "country": "Deutschland",
+            "areas": [
+                "Rudolstadt und Umgebung"
+            ],
+            "city": "Rudolstadt",
+            "zip": "07407",
+            "street": "Schillerstraße 25",
+            "phone": "+ 49 3672 / 486470",
+            "fax": "+ 49 3672 / 486475",
+            "web": "http://www.schillerhaus.rudolstadt.de/",
+            "email": "schillerhaus@rudolstadt.de",
+            "author": "support@hubermedia.de",
+            "media_objects": [
+            ],
+            "keywords": [],
+            "timeIntervals": [
+                {
+                    "weekdays": [],
+                    "start": "2099-12-19T15:00:00+01:00",
+                    "end": "2099-12-19T16:30:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "interval": 1
+                }
+            ],
+            "name": "Schillerhaus Rudolstadt",
+            "features": [
+            ],
+            "addresses": [
+            ],
+            "created": "2099-10-31T12:29:00+00:00",
+            "changed": "2099-12-14T08:29:00+00:00",
+            "source": {
+                "url": "https://example.com/something-else",
+                "value": "Foreign Example 2"
+            },
+            "company": "",
+            "district": "",
+            "postoffice": "",
+            "phone2": "",
+            "seasons": [],
+            "subitems": [],
+            "hyperObjects": []
+        }
+    ]
+}

--- a/Tests/Functional/Import/DestinationDataTest/ImportsExampleAsExpectedTest.php
+++ b/Tests/Functional/Import/DestinationDataTest/ImportsExampleAsExpectedTest.php
@@ -10,6 +10,20 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ImportsExampleAsExpectedTest extends AbstractTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpConfiguration([
+            'restUrl = https://example.com/some-path/',
+            'license = example-license',
+            'restType = Event',
+            'restLimit = 3',
+            'restMode = next_months,12',
+            'restTemplate = ET2014A.json',
+        ]);
+    }
+
     /**
      * @test
      */
@@ -20,14 +34,6 @@ class ImportsExampleAsExpectedTest extends AbstractTest
         $this->importPHPDataSet(__DIR__ . '/Fixtures/Database/SingleImportConfigurationWithCategories.php');
         $this->importPHPDataSet(__DIR__ . '/Fixtures/Database/SingleRegion.php');
         $this->importPHPDataSet(__DIR__ . '/Fixtures/Database/SingleCategory.php');
-        $this->setUpConfiguration([
-            'restUrl = https://example.com/some-path/',
-            'license = example-license',
-            'restType = Event',
-            'restLimit = 3',
-            'restMode = next_months,12',
-            'restTemplate = ET2014A.json',
-        ]);
 
         $requests = &$this->setUpResponses([
             new Response(200, [], file_get_contents(__DIR__ . '/Fixtures/Response.json') ?: ''),
@@ -70,6 +76,22 @@ class ImportsExampleAsExpectedTest extends AbstractTest
             'Got unexpected number of files'
         );
 
+        $this->assertEmptyLog();
+    }
+
+    /**
+     * @test
+     */
+    public function importsSource(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/Database/DefaultImportConfiguration.php');
+        $this->setUpResponses([
+            new Response(200, [], file_get_contents(__DIR__ . '/Fixtures/ResponseWithSources.json') ?: ''),
+        ]);
+
+        $this->executeCommand();
+
+        $this->assertPHPDataSet(__DIR__ . '/Assertions/ImportsSource.php');
         $this->assertEmptyLog();
     }
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -22,6 +22,8 @@ CREATE TABLE tx_events_domain_model_event (
     partner text,
     region int(11) unsigned DEFAULT '0',
     references_events text,
+    source_name varchar(255) DEFAULT '' NOT NULL,
+    source_url varchar(255) DEFAULT '' NOT NULL,
     KEY dataHandler (l10n_parent, t3ver_oid, deleted, t3ver_wsid, t3ver_state)
 );
 


### PR DESCRIPTION
Destination Data One provides an source info explaining where the data originally came from.
This is now added to event records and exposed in TYPO3 backend. That allows editors to check the source and contact corresponding sources in order to fix broken data.

Relates: #10630