### PR TITLE
Allow to change highlight via backend form

### DIFF
--- a/Configuration/TCA/tx_events_domain_model_event.php
+++ b/Configuration/TCA/tx_events_domain_model_event.php
@@ -232,9 +232,12 @@ return [
             'label' => $l10nPath . ':tx_events_domain_model_event.highlight',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
-                    '1' => [
-                        '0' => $l10nPathLang . ':labels.enabled',
+                    [
+                        0 => '',
+                        1 => '',
+                        'invertStateDisplay' => false,
                     ],
                 ],
                 'default' => 0,

--- a/Documentation/Changelog/3.5.2.rst
+++ b/Documentation/Changelog/3.5.2.rst
@@ -1,0 +1,30 @@
+3.5.2
+=====
+
+Breaking
+--------
+
+Nothing
+
+Features
+--------
+
+Nothing
+
+Fixes
+-----
+
+* Fix broken TCA for highlight property.
+  The highlight could not be saved.
+  An unexpected value (3) was submitted on selection.
+  We now migrated the property to look and act the same as hidden input.
+
+Tasks
+-----
+
+Nothing
+
+Deprecation
+-----------
+
+Nothing


### PR DESCRIPTION
It was not possible to change the value of highlight for events due to broken TCA.
This got fixed. The input is now streamlined to look the same as hidden to not irritate users.

Relates: #10782