### PR TITLE
Provide Page Titles

### DIFF
--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -70,7 +70,7 @@ class Event extends AbstractEntity
      */
     protected ObjectStorage $features;
 
-    protected string $keywords;
+    protected string $keywords = '';
 
     /**
      * @var ObjectStorage<Partner>

--- a/Classes/Frontend/MetaInformation/DateMetaInformationService.php
+++ b/Classes/Frontend/MetaInformation/DateMetaInformationService.php
@@ -25,6 +25,7 @@ namespace WerkraumMedia\Events\Frontend\MetaInformation;
 
 use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
 use WerkraumMedia\Events\Domain\Model\Date;
+use WerkraumMedia\Events\Frontend\PageTitleProvider\DateTitleProviderInterface;
 
 /**
  * TYPO3 has many different APIs to set meta information like: Page Title, Meta Tags, OpenGraph Tags, etc.
@@ -34,7 +35,8 @@ use WerkraumMedia\Events\Domain\Model\Date;
 final class DateMetaInformationService implements DateMetaInformationInterface
 {
     public function __construct(
-        private readonly MetaTagManagerRegistry $metaTagManagerRegistry
+        private readonly MetaTagManagerRegistry $metaTagManagerRegistry,
+        private readonly DateTitleProviderInterface $titleProvider
     ) {
     }
 
@@ -42,6 +44,8 @@ final class DateMetaInformationService implements DateMetaInformationInterface
     {
         $this->setDescription($date);
         $this->setKeywords($date);
+
+        $this->titleProvider->setDate($date);
     }
 
     private function setDescription(Date $date): void

--- a/Classes/Frontend/MetaInformation/EventMetaInformationService.php
+++ b/Classes/Frontend/MetaInformation/EventMetaInformationService.php
@@ -25,6 +25,7 @@ namespace WerkraumMedia\Events\Frontend\MetaInformation;
 
 use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
 use WerkraumMedia\Events\Domain\Model\Event;
+use WerkraumMedia\Events\Frontend\PageTitleProvider\EventTitleProviderInterface;
 
 /**
  * TYPO3 has many different APIs to set meta information like: Page Title, Meta Tags, OpenGraph Tags, etc.
@@ -34,7 +35,8 @@ use WerkraumMedia\Events\Domain\Model\Event;
 final class EventMetaInformationService implements EventMetaInformationInterface
 {
     public function __construct(
-        private readonly MetaTagManagerRegistry $metaTagManagerRegistry
+        private readonly MetaTagManagerRegistry $metaTagManagerRegistry,
+        private readonly EventTitleProviderInterface $titleProvider
     ) {
     }
 
@@ -42,6 +44,8 @@ final class EventMetaInformationService implements EventMetaInformationInterface
     {
         $this->setDescription($event);
         $this->setKeywords($event);
+
+        $this->titleProvider->setEvent($event);
     }
 
     private function setDescription(Event $event): void

--- a/Classes/Frontend/PageTitleProvider/DateTitleProvider.php
+++ b/Classes/Frontend/PageTitleProvider/DateTitleProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\Events\Frontend\PageTitleProvider;
+
+use WerkraumMedia\Events\Domain\Model\Date;
+
+final class DateTitleProvider implements DateTitleProviderInterface
+{
+    private ?Date $date = null;
+
+    public function setDate(Date $date): void
+    {
+        $this->date = $date;
+    }
+
+    public function getTitle(): string
+    {
+        if ($this->date === null || $this->date->getEvent() === null) {
+            return '';
+        }
+
+        return implode(' ', [
+            $this->date->getEvent()->getTitle(),
+            $this->date->getStart()->format('d.m.Y H:i'),
+        ]);
+    }
+}

--- a/Classes/Frontend/PageTitleProvider/DateTitleProviderInterface.php
+++ b/Classes/Frontend/PageTitleProvider/DateTitleProviderInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\Events\Frontend\PageTitleProvider;
+
+use TYPO3\CMS\Core\PageTitle\PageTitleProviderInterface;
+use TYPO3\CMS\Core\SingletonInterface;
+use WerkraumMedia\Events\Domain\Model\Date;
+
+interface DateTitleProviderInterface extends PageTitleProviderInterface, SingletonInterface
+{
+    public function setDate(Date $date): void;
+}

--- a/Classes/Frontend/PageTitleProvider/EventTitleProvider.php
+++ b/Classes/Frontend/PageTitleProvider/EventTitleProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\Events\Frontend\PageTitleProvider;
+
+use WerkraumMedia\Events\Domain\Model\Event;
+
+final class EventTitleProvider implements EventTitleProviderInterface
+{
+    private ?Event $event = null;
+
+    public function setEvent(Event $event): void
+    {
+        $this->event = $event;
+    }
+
+    public function getTitle(): string
+    {
+        if ($this->event === null) {
+            return '';
+        }
+
+        return $this->event->getTitle();
+    }
+}

--- a/Classes/Frontend/PageTitleProvider/EventTitleProviderInterface.php
+++ b/Classes/Frontend/PageTitleProvider/EventTitleProviderInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\Events\Frontend\PageTitleProvider;
+
+use TYPO3\CMS\Core\PageTitle\PageTitleProviderInterface;
+use TYPO3\CMS\Core\SingletonInterface;
+use WerkraumMedia\Events\Domain\Model\Event;
+
+interface EventTitleProviderInterface extends PageTitleProviderInterface, SingletonInterface
+{
+    public function setEvent(Event $event): void;
+}

--- a/Documentation/Changelog/4.0.0.rst
+++ b/Documentation/Changelog/4.0.0.rst
@@ -33,6 +33,9 @@ Features
 * Import keywords for events from destination.one.
   That way keywords are available for usage in meta tags.
 
+* Add page title provider.
+  That way it is possible to alter the TYPO3 page title when showing a date or event.
+
 Fixes
 -----
 

--- a/Documentation/Features/PageTitle.rst
+++ b/Documentation/Features/PageTitle.rst
@@ -1,0 +1,15 @@
+.. index:: single: page title
+.. _pageTitle:
+
+Page Title
+==========
+
+The extension comes with default implementations for PageTitleProvider.
+
+The default implementation can be exchanged by leveraging TYPO3 Dependency Injection.
+
+Further resources:
+
+* https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Seo/PageTitleApi.html
+
+* https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/DependencyInjection/Index.html

--- a/Tests/Functional/Frontend/DatesTest.php
+++ b/Tests/Functional/Frontend/DatesTest.php
@@ -204,4 +204,20 @@ class DatesTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('<meta name="description" content="Teaser of Event" />', $html);
         self::assertStringContainsString('<meta name="keywords" content="Gewölbe, Goethe, Horst Damm, Kästner, Theater" />', $html);
     }
+
+    #[Test]
+    public function altersPageTitle(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/DatesTestFixtures/DatePageTitle.php');
+
+        $request = new InternalRequest();
+        $request = $request->withPageId(1);
+        $request = $request->withQueryParameter('tx_events_dateshow[date]', '1');
+        $response = $this->executeFrontendSubRequest($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $html = (string)$response->getBody();
+
+        self::assertStringContainsString('<title>Title of Event 15.02.2023 00:00</title>', $html);
+    }
 }

--- a/Tests/Functional/Frontend/DatesTestFixtures/DatePageTitle.php
+++ b/Tests/Functional/Frontend/DatesTestFixtures/DatePageTitle.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+return  [
+    'tt_content' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '1',
+            'CType' => 'list',
+            'list_type' => 'events_dateshow',
+            'header' => 'Singleview',
+        ],
+    ],
+    'tx_events_domain_model_event' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '2',
+            'title' => 'Title of Event',
+            'hidden' => '0',
+        ],
+    ],
+    'tx_events_domain_model_date' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '2',
+            'event' => '1',
+            'start' => '1676419200',
+            'end' => '1676484000',
+        ],
+    ],
+];

--- a/Tests/Functional/Frontend/EventsTest.php
+++ b/Tests/Functional/Frontend/EventsTest.php
@@ -57,4 +57,20 @@ class EventsTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('<meta name="description" content="Teaser of Event" />', $html);
         self::assertStringContainsString('<meta name="keywords" content="Gewölbe, Goethe, Horst Damm, Kästner, Theater" />', $html);
     }
+
+    #[Test]
+    public function altersPageTitle(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/EventsTestFixtures/EventPageTitle.php');
+
+        $request = new InternalRequest();
+        $request = $request->withPageId(1);
+        $request = $request->withQueryParameter('tx_events_eventshow[event]', '1');
+        $response = $this->executeFrontendSubRequest($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $html = (string)$response->getBody();
+
+        self::assertStringContainsString('<title>Title of Event</title>', $html);
+    }
 }

--- a/Tests/Functional/Frontend/EventsTestFixtures/EventPageTitle.php
+++ b/Tests/Functional/Frontend/EventsTestFixtures/EventPageTitle.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return  [
+    'tt_content' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '1',
+            'CType' => 'list',
+            'list_type' => 'events_eventshow',
+            'header' => 'Singleview',
+        ],
+    ],
+    'tx_events_domain_model_event' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '2',
+            'title' => 'Title of Event',
+            'hidden' => '0',
+        ],
+    ],
+];

--- a/Tests/Functional/Frontend/Fixtures/TypoScript/Rendering.typoscript
+++ b/Tests/Functional/Frontend/Fixtures/TypoScript/Rendering.typoscript
@@ -38,3 +38,16 @@ plugin.tx_events {
         start = 1660158000
     }
 }
+
+config {
+    pageTitleProviders {
+        date {
+            provider = WerkraumMedia\Events\Frontend\PageTitleProvider\DateTitleProvider
+            before = record
+        }
+        event {
+            provider = WerkraumMedia\Events\Frontend\PageTitleProvider\EventTitleProvider
+            before = record
+        }
+    }
+}


### PR DESCRIPTION
That way it is possible to alter the TYPO3 page title when showing a date or event.

Relates: #10640