### PR TITLE
Add grouping of locations.

### DIFF
--- a/Configuration/TCA/tx_events_domain_model_location.php
+++ b/Configuration/TCA/tx_events_domain_model_location.php
@@ -21,6 +21,7 @@ return [
             'starttime' => 'starttime',
             'endtime' => 'endtime',
         ],
+        'default_sortby' => 'name',
         'searchFields' => 'name',
         'iconfile' => 'EXT:events/Resources/Public/Icons/tx_events_domain_model_location.svg',
     ],
@@ -32,7 +33,6 @@ return [
                     l10n_diffsource,
                     hidden,
                     name,
-                    global_id,
 
                     street,
                     district,
@@ -42,6 +42,10 @@ return [
                     phone,
                     latitude,
                     longitude,
+                --div--;' . $l10nPath . ':tabs.grouping,
+                    children,
+                --div--;' . $l10nPath . ':tabs.tech,
+                    global_id,
                 --div--;' . $l10nPath . ':tabs.access,
                     starttime,
                     endtime',
@@ -125,6 +129,20 @@ return [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
+            ],
+        ],
+        'children' => [
+            'exclude' => true,
+            'label' => $l10nPath . ':tx_events_domain_model_location.children',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'foreign_table' => 'tx_events_domain_model_location',
+                'fieldControl' => [
+                    'editPopup' => [
+                        'disabled' => false,
+                    ],
+                ],
             ],
         ],
         'name' => [

--- a/Documentation/Changelog/3.9.0.rst
+++ b/Documentation/Changelog/3.9.0.rst
@@ -1,4 +1,4 @@
-4.1.0
+3.9.0
 =====
 
 Breaking
@@ -9,8 +9,6 @@ Nothing
 Features
 --------
 
-Forward ported from 3.9.0:
-
 * Add grouping of locations.
   It is now possible to group locations.
   Each location can have arbitrary children.
@@ -19,6 +17,17 @@ Forward ported from 3.9.0:
   Filtering for a location will always find all dates where the location or one of the child locations is assigned.
 
   One use case can be to group imported locations and provide a grouped location for filtering in frontend.
+
+Backport of 4.0.0 features:
+
+* Add meta tags.
+  A new class is added which will add meta tags for dates and events.
+  The class has an interface which allows it to be replaced via DI to alter behaviour.
+
+* Import keywords for events from destination.one.
+  That way keywords are available for usage in meta tags.
+
+* Add page title provider. That way it is possible to alter the TYPO3 page title when showing a date or event.
 
 Fixes
 -----

--- a/Resources/Private/Language/de.locallang_csh_location.xlf
+++ b/Resources/Private/Language/de.locallang_csh_location.xlf
@@ -7,6 +7,18 @@
                 <source>Location</source>
                 <target>Veranstaltungsort</target>
             </trans-unit>
+            <trans-unit id="tabs.grouping" xml:space="preserve">
+                <source>Grouping</source>
+                <target>Gruppierung</target>
+            </trans-unit>
+            <trans-unit id="tabs.tech" xml:space="preserve">
+                <source>Tech</source>
+                <target>Technik</target>
+            </trans-unit>
+            <trans-unit id="tabs.access" xml:space="preserve">
+                <source>Access</source>
+                <target>Zugriff</target>
+            </trans-unit>
             <trans-unit id="tx_events_domain_model_location.global_id" xml:space="preserve">
                 <source>Global UID</source>
                 <target>Globale UID</target>
@@ -15,9 +27,9 @@
                 <source>Auto generated from the values.</source>
                 <target>Wird automatisch aus den Werten generiert.</target>
             </trans-unit>
-            <trans-unit id="tx_events_domain_model_location.slug" xml:space="preserve">
-                <source>Slug</source>
-                <target>URL-Segment</target>
+            <trans-unit id="tx_events_domain_model_location.children" xml:space="preserve">
+                <source>Children</source>
+                <target>Kinder</target>
             </trans-unit>
             <trans-unit id="tx_events_domain_model_location.name" xml:space="preserve">
                 <source>Name</source>

--- a/Resources/Private/Language/locallang_csh_location.xlf
+++ b/Resources/Private/Language/locallang_csh_location.xlf
@@ -6,14 +6,23 @@
             <trans-unit id="tx_events_domain_model_location" xml:space="preserve">
                 <source>Location</source>
             </trans-unit>
+            <trans-unit id="tabs.grouping" xml:space="preserve">
+                <source>Grouping</source>
+            </trans-unit>
+            <trans-unit id="tabs.tech" xml:space="preserve">
+                <source>Tech</source>
+            </trans-unit>
+            <trans-unit id="tabs.access" xml:space="preserve">
+                <source>Access</source>
+            </trans-unit>
             <trans-unit id="tx_events_domain_model_location.global_id" xml:space="preserve">
                 <source>Global UID</source>
             </trans-unit>
             <trans-unit id="tx_events_domain_model_location.global_id.description" xml:space="preserve">
                 <source>Auto generated from the values.</source>
             </trans-unit>
-            <trans-unit id="tx_events_domain_model_location.slug" xml:space="preserve">
-                <source>Slug</source>
+            <trans-unit id="tx_events_domain_model_location.children" xml:space="preserve">
+                <source>Children</source>
             </trans-unit>
             <trans-unit id="tx_events_domain_model_location.name" xml:space="preserve">
                 <source>Name</source>

--- a/Tests/Functional/Frontend/FilterTest.php
+++ b/Tests/Functional/Frontend/FilterTest.php
@@ -49,4 +49,20 @@ class FilterTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('Lotte in Weimar', $html);
         self::assertStringContainsString('Was hat das Universum mit mir zu tun?', $html);
     }
+
+    #[Test]
+    public function canFilterDatesByParentLocationViaFlexform(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/Database/FilterDatesByParentLocationViaFlexform.php');
+
+        $request = new InternalRequest('https://example.com/');
+        $request = $request->withPageId(1);
+        $response = $this->executeFrontendSubRequest($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $html = (string)$response->getBody();
+
+        self::assertStringContainsString('Lotte in Weimar', $html);
+        self::assertStringContainsString('Was hat das Universum mit mir zu tun?', $html);
+    }
 }

--- a/Tests/Functional/Frontend/Fixtures/Database/FilterDatesByParentLocationViaFlexform.php
+++ b/Tests/Functional/Frontend/Fixtures/Database/FilterDatesByParentLocationViaFlexform.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'tt_content' => [
+        [
+            'pid' => '1',
+            'uid' => '1',
+            'CType' => 'list',
+            'list_type' => 'events_datelist',
+            'header' => 'Kino Events',
+            'pi_flexform' => '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+                <T3FlexForms>
+                    <data>
+                        <sheet index="sDEF">
+                            <language index="lDEF">
+                                <field index="settings.locations">
+                                    <value index="vDEF">1</value>
+                                </field>
+                            </language>
+                        </sheet>
+                    </data>
+                </T3FlexForms>
+            ',
+        ],
+    ],
+    'tx_events_domain_model_location' => [
+        [
+            'uid' => '1',
+            'pid' => '2',
+            'name' => 'Parent',
+            'street' => '',
+            'city' => '',
+            'zip' => '',
+            'country' => '',
+            'longitude' => '',
+            'latitude' => '',
+            'children' => '2,3',
+        ],
+        [
+            'uid' => '2',
+            'pid' => '2',
+            'name' => 'Child',
+            'street' => 'Theaterplatz 4',
+            'city' => 'Weimar',
+            'zip' => '99423',
+            'country' => 'Deutschland',
+            'longitude' => '11.3262489',
+            'latitude' => '50.9800023',
+            'district' => 'Zentrum',
+            // Validate we don't end in endless recursion
+            'children' => '1',
+        ],
+        [
+            'uid' => '3',
+            'pid' => '2',
+            'name' => 'Child 2',
+            'street' => 'Cranach-Haus Markt 11/12',
+            'city' => 'Weimar',
+            'zip' => '99423',
+            'country' => 'Deutschland',
+            'longitude' => '11.330248',
+            'latitude' => '50.979349',
+            'children' => '',
+        ],
+    ],
+    'tx_events_domain_model_event' => [
+        [
+            'uid' => '1',
+            'pid' => '2',
+            'title' => 'Was hat das Universum mit mir zu tun?',
+            'global_id' => 'e_100478529',
+            'teaser' => '„WAS HAT DAS UNIVERSUM MIT MIR ZU TUN?“
+            Ein Abend mit Prof. Dr. Harald Lesch',
+            'details' => '„WAS HAT DAS UNIVERSUM MIT MIR ZU TUN?“
+            Ein Abend mit Prof. Dr. Harald Lesch
+            Auf den Spuren von Goethes Naturphilosophie ist der Astrophysiker und Wissenschaftsjournalist Prof. Dr. Harald Lesch in Weimar schon mehrmals präsent gewesen. Jetzt hält er einen Vortrag zu keiner geringeren Frage als „Was hat das Universum mit mir zu tun?“ Ob Goethe darauf eine pointierte Antwort eingefallen wäre? Sein Faust wollte die Spur seiner Erdentage nicht in Äonen untergehen sehen. Harald Lesch behauptet: Wir sind und bleiben stets Teil der Äonen - denn „wir sind alle Sternenstaub. Vor einer halben Ewigkeit ist ein Stern explodiert und hat alle Stoffe aus denen wir bestehen hervorgebracht. Und wenn das bei uns geklappt hat, könnte es auch noch woanders passiert sein.“ Erleben Sie einen faszinierenden Mix aus Rednerkunst und virtuoser musikalischer Begleitung. Neben Prof. Dr. Harald Lesch begibt sich der Musiker Hans Raths (Bayon) mit auf die Reise ins theatralische und philosophische Universum. Eine Veranstaltung nicht nur für Science-Fiction-Freaks, sondern für alle Kosmopoliten!',
+            'price_info' => 'Preis inklusive Platzierung mit Namensschild und einem Pausengetränk Ihrer Wahl',
+            'location' => '3',
+        ],
+        [
+            'uid' => '2',
+            'pid' => '2',
+            'title' => 'Lotte in Weimar',
+            'global_id' => 'e_100453137',
+            'teaser' => 'Ein „Goethe-Götter-Lustspiel“ nach dem gleichnamigen Roman von Thomas Mann',
+            'details' => 'LOTTE IN WEIMAR
+            Ein „Goethe-Götter-Lustspiel“ nach dem gleichnamigen Roman von Thomas Mann
+            „Welch buchenswertes Ereignis!“, ruft der Kellner Mager aus, als er erfährt, wer da in seinem Gasthaus „Zum Elephanten“ abgestiegen ist: Die berühmte Heldin aus Goethes „Die Leiden des jungen Werthers“, Charlotte Kestner, geborene Buff aus Wetzlar, – das „Urbild“ der Lotte sozusagen! Eine heiter-ironische Abrechnung mit dem Starkult anno 1816 fast am Originalschauplatz. Mit Regine Heintze, Heike Meyer und Detlef Heintze. Inszenierung: Michael Kliefert/ Detlef Heintze.',
+            'price_info' => 'Preise inklusive Platzierung mit Namensschild und einem Pausengetränk Ihrer Wahl (ermäßigt alkoholfrei)',
+            'location' => '2',
+        ],
+    ],
+    'tx_events_domain_model_date' => [
+        [
+            'uid' => '1',
+            'pid' => '2',
+            'event' => '1',
+            'start' => '1661626800',
+            'end' => '1661632200',
+        ],
+        [
+            'uid' => '2',
+            'pid' => '2',
+            'event' => '1',
+            'start' => '1660158000',
+            'end' => '1660163400',
+        ],
+        [
+            'uid' => '3',
+            'pid' => '2',
+            'event' => '2',
+            'start' => '1661194800',
+            'end' => '1661200200',
+        ],
+    ],
+];

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -98,6 +98,7 @@ CREATE TABLE tx_events_domain_model_location (
     phone varchar(255) DEFAULT '' NOT NULL,
     latitude varchar(255) DEFAULT '' NOT NULL,
     longitude varchar(255) DEFAULT '' NOT NULL,
+    children text,
 
     KEY global_id (global_id)
 );


### PR DESCRIPTION
It is now possible to group locations.
Each location can have arbitrary children.

That can be used for editorial structuring.
Filtering for a location will always find all dates where the location or one of the child locations is assigned.

One use case can be to group imported locations and provide a grouped location for filtering in frontend.

Relates: #11233