### PR TITLE
Handle destination.one files without file name.

### DIFF
--- a/Documentation/Changelog/4.2.1.rst
+++ b/Documentation/Changelog/4.2.1.rst
@@ -28,6 +28,13 @@ Fixes
   back to `date_default_timezone_get()` call.
   That way it should be useful for most systems out of the box.
 
+* Handle destination.one files without file name.
+
+  It is possible to have files such as `https://dam.destination.one/2675868/3dc0a9dccd0dad46c73e669ece428c634ff8324ea3d01a4858a1c43169deed41/.jpg`.
+  Those were not handled correctly yet.
+  We now also handle those cases.
+  We will generate a hash from the URL as file name in order to still use those files.
+
 Tasks
 -----
 

--- a/Tests/Functional/Import/DestinationDataTest/Assertions/ImportHandlesImageWithoutFileName.php
+++ b/Tests/Functional/Import/DestinationDataTest/Assertions/ImportHandlesImageWithoutFileName.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Resource\File;
+
+return [
+    'sys_file' => [
+        [
+            'uid' => 1,
+            'pid' => 0,
+            'missing' => 0,
+            'storage' => 1,
+            'type' => File::FILETYPE_IMAGE,
+            'identifier' => '/staedte/beispielstadt/events/bf126089c94f95031fa07bf9d7d9b10c3e58aafebdef31f0b60604da13019b8d.jpg',
+            'extension' => 'jpg',
+            'name' => 'bf126089c94f95031fa07bf9d7d9b10c3e58aafebdef31f0b60604da13019b8d.jpg',
+        ],
+    ],
+    'sys_file_reference' => [
+        [
+            'uid' => 1,
+            'pid' => 2,
+            'uid_local' => 1,
+            'uid_foreign' => 1,
+            'tablenames' => 'tx_events_domain_model_event',
+            'fieldname' => 'images',
+            'sorting_foreign' => 1,
+            'title' => null,
+            'description' => null,
+            'alternative' => null,
+        ],
+    ],
+    'sys_file_metadata' => [
+        [
+            'uid' => 1,
+            'pid' => 0,
+            'file' => 1,
+            'title' => null,
+        ],
+    ],
+];

--- a/Tests/Functional/Import/DestinationDataTest/Fixtures/ResponseWithNewImageWithoutFileName.json
+++ b/Tests/Functional/Import/DestinationDataTest/Fixtures/ResponseWithNewImageWithoutFileName.json
@@ -1,0 +1,33 @@
+{
+    "items": [
+        {
+            "global_id": "e_100347853",
+            "title": "Allerlei Weihnachtliches (Heute mit Johannes Geißer)",
+            "media_objects": [
+                {
+                    "rel": "default",
+                    "url": "https://dam.destination.one/849917/279ac45b3fc701a7197131f627164fffd9f8cc77bc75165e2fc2b864ed606920/.jpg",
+                    "type": "image/jpeg",
+                    "latitude": null,
+                    "longitude": null,
+                    "width": 1920,
+                    "height": 1080,
+                    "value": ""
+                }
+            ],
+            "timeIntervals": [
+                {
+                    "weekdays": [],
+                    "start": "2022-12-19T15:00:00+01:00",
+                    "end": "2022-12-19T16:30:00+01:00",
+                    "tz": "Europe/Berlin",
+                    "interval": 1
+                }
+            ],
+            "source": {
+                "url": "http://destination.one/",
+                "value": "destination.one"
+            }
+        }
+    ]
+}

--- a/Tests/Functional/Import/DestinationDataTest/ImportHandlesImagesTest.php
+++ b/Tests/Functional/Import/DestinationDataTest/ImportHandlesImagesTest.php
@@ -61,6 +61,31 @@ class ImportHandlesImagesTest extends AbstractTestCase
     }
 
     #[Test]
+    public function addsNewImageWithoutFileName(): void
+    {
+        $this->setUpResponses([
+            new Response(200, [], file_get_contents(__DIR__ . '/Fixtures/ResponseWithNewImageWithoutFileName.json') ?: ''),
+            new Response(200, [], file_get_contents(__DIR__ . '/Fixtures/ExampleImage.jpg') ?: ''),
+        ]);
+
+        $this->executeCommand();
+
+        $this->assertPHPDataSet(__DIR__ . '/Assertions/ImportHandlesImageWithoutFileName.php');
+
+        $importedFiles = GeneralUtility::getFilesInDir($this->fileImportPath);
+        self::assertIsArray($importedFiles, 'Failed to retrieve imported files from filesystem.');
+        self::assertSame(
+            [
+                'bf126089c94f95031fa07bf9d7d9b10c3e58aafebdef31f0b60604da13019b8d.jpg',
+            ],
+            array_values($importedFiles),
+            'Got unexpected number of files'
+        );
+
+        $this->assertEmptyLog();
+    }
+
+    #[Test]
     public function addsMultipleImagesToSingleEvent(): void
     {
         $this->setUpResponses([


### PR DESCRIPTION
It is possible to have files such as
`https://dam.destination.one/2675868/3dc0a9dccd0dad46c73e669ece428c634ff8324ea3d01a4858a1c43169deed41/.jpg`. Those were not handled correctly yet.
We now also handle those cases.
We will generate a hash from the URL as file name in order to still use those files.

Relates: #11396