### PR TITLE
Properly define dependency to TYPO3 v14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,13 +54,13 @@ jobs:
           - php-version: '8.5'
             typo3-version: '^13.4'
           - php-version: '8.2'
-            typo3-version: '^14'
+            typo3-version: '~14.2.0'
           - php-version: '8.3'
-            typo3-version: '^14'
+            typo3-version: '~14.2.0'
           - php-version: '8.4'
-            typo3-version: '^14'
+            typo3-version: '~14.2.0'
           - php-version: '8.5'
-            typo3-version: '^14'
+            typo3-version: '~14.2.0'
     steps:
       - uses: 'actions/checkout@v3'
 

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "doctrine/dbal": "^4.3",
         "symfony/console": "^7.2 || 7.3",
         "symfony/dependency-injection": "^7.2 || ^7.3",
-        "typo3/cms-core": "^13.4 || ^14.2",
-        "typo3/cms-extbase": "^13.4 || ^14.2",
-        "typo3/cms-filelist": "^13.4 || ^14.2",
-        "typo3/cms-filemetadata": "^13.4 || ^14.2",
-        "typo3/cms-fluid": "^13.4 || ^14.2",
-        "typo3/cms-frontend": "^13.4 || ^14.2",
-        "typo3/cms-install": "^13.4 || ^14.2"
+        "typo3/cms-core": "^13.4 || ~14.2.0",
+        "typo3/cms-extbase": "^13.4 || ~14.2.0",
+        "typo3/cms-filelist": "^13.4 || ~14.2.0",
+        "typo3/cms-filemetadata": "^13.4 || ~14.2.0",
+        "typo3/cms-fluid": "^13.4 || ~14.2.0",
+        "typo3/cms-frontend": "^13.4 || ~14.2.0",
+        "typo3/cms-install": "^13.4 || ~14.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -72,9 +72,9 @@
         "phpstan/phpstan-phpunit": "2.0.16",
         "saschaegerer/phpstan-typo3": "2.1.1 || 3.0.1",
         "staabm/phpstan-todo-by": "^0.3.3",
-        "typo3/cms-backend": "^13.4 || ^14.2",
-        "typo3/cms-fluid-styled-content": "^13.4 || ^14.2",
-        "typo3/cms-seo": "^13.4 || ^14.2",
+        "typo3/cms-backend": "^13.4 || ~14.2.0",
+        "typo3/cms-fluid-styled-content": "^13.4 || ~14.2.0",
+        "typo3/cms-seo": "^13.4 || ~14.2.0",
         "typo3/testing-framework": "^9.4"
     },
     "config": {


### PR DESCRIPTION
We do not support 14.3 or newer.
We explicitly only mark the supported version, until LTS release happened.