### PR TITLE
Wrong date creation based on destination.one repeatUntil

### DIFF
--- a/Classes/Domain/DestinationData/Date.php
+++ b/Classes/Domain/DestinationData/Date.php
@@ -127,9 +127,12 @@ final class Date
         $date = new DateTimeImmutable($this->data['repeatUntil'], $this->getTimezone());
         $date = $date->setTime(
             (int)$this->getStart()->format('H'),
-            (int)$this->getStart()->format('m'),
+            (int)$this->getStart()->format('i'),
             (int)$this->getStart()->format('s'),
         );
+
+        // Workaround for PHP <8.2 where DatePeriod does not yet have DatePeriod::INCLUDE_END_DATE
+        $date = $date->modify('+1second');
 
         return $date;
     }

--- a/Classes/Domain/DestinationData/Date.php
+++ b/Classes/Domain/DestinationData/Date.php
@@ -132,7 +132,13 @@ final class Date
         );
 
         // Workaround for PHP <8.2 where DatePeriod does not yet have DatePeriod::INCLUDE_END_DATE
-        $date = $date->modify('+1second');
+        // If start + 1day (which is not included) is last until, we need to increase until to include that day.
+        // Otherwise another day would lead to issues, so we use only one second.
+        if ($date->format('d.m.Y') === $this->getStart()->modify('+1day')->format('d.m.Y')) {
+            $date = $date->modify('+1day');
+        } else {
+            $date = $date->modify('+1second');
+        }
 
         return $date;
     }

--- a/Documentation/Changelog/6.0.0.rst
+++ b/Documentation/Changelog/6.0.0.rst
@@ -14,7 +14,13 @@ Features
 Fixes
 -----
 
-Nothing
+* Fix wrong determination of repeat minutes
+
+  The used value was for month instead of minutes.
+  We now use the correct identifier for minutes.
+
+  This revealed that tests only passed because of the issue.
+  We therefore fix the code to still pass correct tests by working around PHP < 8.2 limitation.
 
 Tasks
 -----

--- a/Documentation/Changelog/6.0.0.rst
+++ b/Documentation/Changelog/6.0.0.rst
@@ -14,6 +14,12 @@ Features
 Fixes
 -----
 
+* Wrong date creation based on destination.one `repeatUntil`.
+  Respect the last day, if we import on that day.
+
+  A new test is added to reflect that situation.
+  The workaround for missing `DatePeriod::INCLUDE_END_DATE` is extended to cover that situation.
+
 * Fix wrong determination of repeat minutes
 
   The used value was for month instead of minutes.

--- a/Tests/Unit/Service/DestinationDataImportService/DatesFactoryTest.php
+++ b/Tests/Unit/Service/DestinationDataImportService/DatesFactoryTest.php
@@ -381,6 +381,34 @@ class DatesFactoryTest extends TestCase
     }
 
     #[Test]
+    public function returnsDatesOnWeeklyBasisIncludingLastDay(): void
+    {
+        $subject = $this->createTestSubject('2026-03-29T16:00:00 Europe/Berlin');
+
+        $result = $subject->createDates([[
+            'weekdays' => [
+                'Saturday',
+                'Sunday',
+            ],
+            'start' => '2026-03-21T16:00:00+02:00',
+            'end' => '2022-03-21T17:00:00+02:00',
+            'repeatUntil' => '2026-03-29T10:00:00+01:00',
+            'tz' => 'Europe/Berlin',
+            'freq' => 'Weekly',
+            'interval' => 1,
+        ]], false);
+
+        self::assertInstanceOf(Generator::class, $result);
+        $result = iterator_to_array($result);
+
+        self::assertCount(1, $result);
+
+        self::assertInstanceOf(Date::class, $result[0]);
+        self::assertSame('2026-03-29T16:00:00+02:00', $result[0]->getStart()->format(DateTimeImmutable::ATOM));
+        self::assertSame('2026-03-29T17:00:00+02:00', $result[0]->getEnd()->format(DateTimeImmutable::ATOM));
+    }
+
+    #[Test]
     public function returnsCanceledDatesOnMixedIntervals(): void
     {
         $subject = $this->createTestSubject('2022-01-01T13:17:24 Europe/Berlin');

--- a/Tests/Unit/Service/DestinationDataImportService/DatesFactoryTest.php
+++ b/Tests/Unit/Service/DestinationDataImportService/DatesFactoryTest.php
@@ -192,6 +192,30 @@ class DatesFactoryTest extends TestCase
     }
 
     #[Test]
+    public function returnsSingleDateForToday(): void
+    {
+        $import = self::createStub(Import::class);
+        $subject = $this->createTestSubject('2026-03-31T15:31:00 Europe/Berlin');
+
+        $result = $subject->createDates($import, [[
+            'start' => '2026-03-31T14:00:00+01:00',
+            'end' => '2026-03-31T15:00:00+01:00',
+            'tz' => 'Europe/Berlin',
+            'interval' => 1,
+        ]], false);
+
+        self::assertInstanceOf(Generator::class, $result);
+
+        $firstEntry = $result->current();
+
+        self::assertCount(1, iterator_to_array($result));
+
+        self::assertInstanceOf(Date::class, $firstEntry);
+        self::assertSame('2026-03-31T14:00:00+01:00', $firstEntry->getStart()->format(DateTimeImmutable::ATOM));
+        self::assertSame('2026-03-31T15:00:00+01:00', $firstEntry->getEnd()->format(DateTimeImmutable::ATOM));
+    }
+
+    #[Test]
     public function returnsMonthlyWithConfiguredRepeatCount(): void
     {
         $import = self::createStub(Import::class);
@@ -384,15 +408,16 @@ class DatesFactoryTest extends TestCase
     public function returnsDatesOnWeeklyBasisIncludingLastDay(): void
     {
         $subject = $this->createTestSubject('2026-03-29T16:00:00 Europe/Berlin');
+        $import = self::createStub(Import::class);
 
-        $result = $subject->createDates([[
+        $result = $subject->createDates($import, [[
             'weekdays' => [
                 'Saturday',
                 'Sunday',
             ],
             'start' => '2026-03-21T16:00:00+02:00',
             'end' => '2022-03-21T17:00:00+02:00',
-            'repeatUntil' => '2026-03-29T10:00:00+01:00',
+            'repeatUntil' => '2026-03-29T16:00:00+02:00',
             'tz' => 'Europe/Berlin',
             'freq' => 'Weekly',
             'interval' => 1,

--- a/Tests/Unit/Service/DestinationDataImportService/DatesFactoryTest.php
+++ b/Tests/Unit/Service/DestinationDataImportService/DatesFactoryTest.php
@@ -323,6 +323,32 @@ class DatesFactoryTest extends TestCase
     }
 
     #[Test]
+    public function returnsDatesOnDailyBasisIncludingLastDay(): void
+    {
+        $subject = $this->createTestSubject('2026-03-31T03:30:00 Europe/Berlin');
+        $import = self::createStub(Import::class);
+
+        $result = $subject->createDates($import, [[
+            'weekdays' => [],
+            'start' => '2026-03-30T14:00:00+01:00',
+            'end' => '2026-03-30T15:00:00+01:00',
+            'repeatUntil' => '2026-03-31T15:00:00+02:00',
+            'tz' => 'Europe/Berlin',
+            'freq' => 'Daily',
+            'interval' => 1,
+        ]], false);
+
+        self::assertInstanceOf(Generator::class, $result);
+        $result = iterator_to_array($result);
+
+        self::assertCount(1, $result);
+
+        self::assertInstanceOf(Date::class, $result[0]);
+        self::assertSame('2026-03-31T14:00:00+02:00', $result[0]->getStart()->format(DateTimeImmutable::ATOM));
+        self::assertSame('2026-03-31T15:00:00+02:00', $result[0]->getEnd()->format(DateTimeImmutable::ATOM));
+    }
+
+    #[Test]
     public function returnsCanceledDatesOnWeeklyBasis(): void
     {
         $subject = $this->createTestSubject('2022-08-29T13:17:24 Europe/Berlin');


### PR DESCRIPTION
Respect the last day, if we import on that day.

A new test is added to reflect that situation.
The workaround for missing `DatePeriod::INCLUDE_END_DATE` is extended to cover that situation.

* Fix wrong determination of repeat minutes

  The used value was for month instead of minutes.
  We now use the correct identifier for minutes.

  This revealed that tests only passed because of the issue.
  We therefore fix the code to still pass correct tests by working around PHP < 8.2 limitation.

* Add test to ensure that weekly basis includes last day

Relates: #12653